### PR TITLE
Update 2.12.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,9 +9,7 @@ source:
   sha256: 9d945a73640e1fec07ee34b42f5669b770c759acd536ec7b16d7e4b87a9c9ff9
 
 build:
-  number: 1
-  # 6/11/2021: skip py<36 causes an unsatisfiable error on win32 with py36
-  #skip: True  # [py<36]
+  number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   entry_points:
     - pylint = pylint:run_pylint
@@ -20,22 +18,20 @@ build:
     - symilar = pylint:run_symilar
 
 requirements:
-  build:
-    - python                   # [build_platform != target_platform]
   host:
     - python
     - pip
-    - pytest-runner
-    - setuptools_scm
     - setuptools
     - wheel
   run:
-    - astroid >=2.6.5,<=2.7
+    - python >=3.6.2
+    - astroid >=2.9.0,<2.10
     - colorama  # [win]
     - isort >=4.2.5,<6
     - mccabe >=0.6,<0.7
-    - python
-    - toml >=0.7.1
+    - platformdirs >=2.2.0
+    - toml >=0.9.2
+    - typing_extensions >=3.10
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.9.6" %}
+{% set version = "2.12.2" %}
 
 package:
   name: pylint
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pylint/pylint-{{ version }}.tar.gz
-  sha256: 8b838c8983ee1904b2de66cce9d0b96649a91901350e956d78f289c3bc87b48e
+  sha256: 9d945a73640e1fec07ee34b42f5669b770c759acd536ec7b16d7e4b87a9c9ff9
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - wheel
   run:
     - python >=3.6.2
-    - astroid >=2.9.0,<2.10
+    - astroid >=2.9.0,<2.10 
     - colorama  # [win]
     - isort >=4.2.5,<6
     - mccabe >=0.6,<0.7


### PR DESCRIPTION
Version change: bump version number from 2.9.6 to 2.12.2
Bug Tracker: new open issues https://github.com/PyCQA/pylint//issues
Github releases:  https://github.com/PyCQA/pylint//releases
Upstream license:  License file:  https://github.com/PyCQA/pylint//blob/master/LICENSE
Upstream Changelog: https://github.com/PyCQA/pylint//blob/main/ChangeLog
Upstream setup.cfg:  https://github.com/PyCQA/pylint/blob/v2.12.2/setup.cfg

The package pylint is mentioned inside the packages:
astroid | ciocheck | neon | python-language-server | spyder | testscenarios |

Actions:
1. Reset build number to 0
2. Update dependencies

Result:
- all-fail