### PR TITLE
Bumping pylint version to 2.14.5 and needed dependencies in meta.yml.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   number: 0
-  skip: True #[py>37]
+  skip: True #[py<37]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   entry_points:
     - pylint = pylint:run_pylint
@@ -28,6 +28,7 @@ requirements:
     - python
     - astroid >=2.11.6,<2.14
     - colorama  # [win]
+    - dill >=0.2
     - isort >=4.2.5,<6
     - mccabe >=0.6,<0.8
     - platformdirs >=2.2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.12.2" %}
+{% set version = "2.14.5" %}
 
 package:
   name: pylint
@@ -9,7 +9,7 @@ source:
   sha256: 9d945a73640e1fec07ee34b42f5669b770c759acd536ec7b16d7e4b87a9c9ff9
 
 build:
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   entry_points:
     - pylint = pylint:run_pylint
@@ -24,13 +24,14 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python >=3.6.2
-    - astroid >=2.9.0,<2.10
+    - python >=3.7.2
+    - astroid >=2.12.2,<2.14
     - colorama  # [win]
     - isort >=4.2.5,<6
     - mccabe >=0.6,<0.8
     - platformdirs >=2.2.0
-    - toml >=0.9.2
+    - toml >=1.1.0
+    - tomlkit >= 0.10.1
     - typing_extensions >=3.10
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,10 +6,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pylint/pylint-{{ version }}.tar.gz
-  sha256: 9d945a73640e1fec07ee34b42f5669b770c759acd536ec7b16d7e4b87a9c9ff9
+  sha256: 487ce2192eee48211269a0e976421f334cf94de1806ca9d0a99449adcdf0285e
 
 build:
   number: 0
+  skip: True #[py>37]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   entry_points:
     - pylint = pylint:run_pylint
@@ -24,7 +25,7 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python >=3.7.2
+    - python
     - astroid >=2.11.6,<2.14
     - colorama  # [win]
     - isort >=4.2.5,<6

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,12 +25,13 @@ requirements:
     - wheel
   run:
     - python >=3.7.2
-    - astroid >=2.12.2,<2.14
+    - astroid >=2.11.6,<2.14
     - colorama  # [win]
     - isort >=4.2.5,<6
     - mccabe >=0.6,<0.8
     - platformdirs >=2.2.0
-    - toml >=1.1.0
+    # 2022/07/25 RSK pylint switched from toml to tomli in 2.13.0
+    - tomli >=1.1.0
     - tomlkit >=0.10.1
     - typing_extensions >=3.10
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,7 +59,9 @@ test:
     - where epylint  # [win]
     - pyreverse --help
     - symilar --help
-    - pylint-config --help
+    # For pylint 2.14.5, pylint-config is currently experimental and throws a warning 
+    #   A warning current causes failure in test.
+    #- pylint-config --help
 
 about:
   home: https://www.pylint.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ build:
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   entry_points:
     - pylint = pylint:run_pylint
+    - pylint-config = pylint:_run_pylint_config
     - epylint = pylint:run_epylint
     - pyreverse = pylint:run_pyreverse
     - symilar = pylint:run_symilar
@@ -25,15 +26,15 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python
+    - python >=3.7.2
     - astroid >=2.11.6,<2.12.0
-    - colorama  # [win]
+    - colorama >=0.4.5 # [win]
     - dill >=0.2
     - isort >=4.2.5,<6
     - mccabe >=0.6,<0.8
     - platformdirs >=2.2.0
     # 2022/07/25 RSK pylint switched from toml to tomli in 2.13.0
-    - tomli >=1.1.0
+    - tomli >=1.1.0 # [py<311]
     - tomlkit >=0.10.1
     - typing_extensions >=3.10
 
@@ -49,10 +50,7 @@ test:
   requires:
     - pip
   commands:
-    # 2022/03/22: Disable pip check because
-    # pylint 2.12.2 has requirement mccabe<0.7,>=0.6, but you have mccabe 0.7.0.
-    # We can safely use mccabe 0.7.0 https://github.com/PyCQA/mccabe/compare/0.6.1...0.7.0, it was released after pylint 2.12.2 and it haven't broken changes
-    #- pip check
+    - pip check
     - pylint --help
     # Has no help option.
     # Running without arguments is an error.
@@ -61,6 +59,7 @@ test:
     - where epylint  # [win]
     - pyreverse --help
     - symilar --help
+    - pylint-config --help
 
 about:
   home: https://www.pylint.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - mccabe >=0.6,<0.8
     - platformdirs >=2.2.0
     - toml >=1.1.0
-    - tomlkit >= 0.10.1
+    - tomlkit >=0.10.1
     - typing_extensions >=3.10
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - wheel
   run:
     - python
-    - astroid >=2.11.6,<2.14
+    - astroid >=2.11.6,<2.12.0
     - colorama  # [win]
     - dill >=0.2
     - isort >=4.2.5,<6


### PR DESCRIPTION
Update to 2.14.5 from last which was 2.12.2

Notable changes:
- Addition of dill and tomlkit as dependency
- Change from toml to tomli as dependency

Github Repo:
https://github.com/PyCQA/pylint/tree/v2.14.5

Reference setup.cfg:
https://github.com/PyCQA/pylint/blob/v2.14.5/setup.cfg

