### PR TITLE
Updated to 3.3.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.2.7" %}
+{% set version = "3.3.3" %}
 
 package:
   name: pylint
@@ -6,11 +6,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pylint/pylint-{{ version }}.tar.gz
-  sha256: 1b7a721b575eaeaa7d39db076b6e7743c993ea44f57979127c517c6c572c803e
+  sha256: 07c607523b17e6d16e2ae0d7ef59602e332caa762af64203c24b41c27139f36a
 
 build:
   number: 0
-  skip: True #[py<38]
+  skip: True #[py<39]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
   entry_points:
     - pylint = pylint:run_pylint
@@ -30,7 +30,7 @@ requirements:
     - dill >=0.3.6  # [py==311]
     - dill >=0.3.7  # [py>=312]
     - platformdirs >=2.2.0
-    - astroid >=3.2.4,<3.3.0
+    - astroid >=3.3.8,<3.4.0
     - isort >=4.2.5,<6,!=5.13.0
     - mccabe >=0.6,<0.8
     - tomli >=1.1.0  # [py<311]
@@ -54,12 +54,13 @@ test:
     - git
     - gitpython
     - pip
-    - py >=1.11.0,<1.12.0
+    - py >=1.11.0,<1.12
     - pytest >=7.4.0,<8
-    - pytest-benchmark >=4.0.0,<5.0.0
+    - pytest-benchmark >=4.0,<5
     - pytest-timeout >=2,<3
+    - pytest-xdist >=3.6,<4
     - requests
-    - typing-extensions >=4.11.0,<5
+    - typing-extensions >=4.12,<5
   source_files:
     - pyproject.toml
     - tests
@@ -89,7 +90,7 @@ about:
     Pylint is a tool that checks for errors in Python code, tries to enforce a
     coding standard and looks for code smells.
   doc_url: https://pylint.readthedocs.io
-  dev_url: https://github.com/PyCQA/pylint/
+  dev_url: https://github.com/pylint-dev/pylint
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
pylint 3.3.3

**Destination channel:** defaults

### Links

- [PKG-6461](https://anaconda.atlassian.net/browse/PKG-6461)
- [Upstream repository](https://github.com/pylint-dev/pylint/tree/v3.3.3)
- [Upstream changelog/diff](https://github.com/pylint-dev/pylint/compare/v3.2.6...v3.3.3)
- Relevant dependency PRs:
  - AnacondaRecipes/astroid-feedstock#32

### Explanation of changes:

- Ignored some test dep updates because they don't seem to be needed and we are holding pytest updates for the 3.13 release


[PKG-6461]: https://anaconda.atlassian.net/browse/PKG-6461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ